### PR TITLE
Move to twilight-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "arc-swap"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+
+[[package]]
+name = "async-trait"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,15 +54,6 @@ name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -100,16 +108,6 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
@@ -134,28 +132,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
  "time",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "command_attr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27d6155f93d880b6379d93ddc9b2417b3b69b715360c5f25525e4576338a381"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -181,15 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-dependencies = [
- "sct",
 ]
 
 [[package]]
@@ -250,6 +218,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -258,6 +227,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -276,12 +260,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -289,6 +289,17 @@ name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -329,9 +340,11 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project",
@@ -367,12 +380,12 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.1",
+ "http",
  "indexmap",
  "log",
  "slab",
@@ -391,22 +404,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -417,8 +419,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
- "http 0.2.1",
+ "bytes",
+ "http",
 ]
 
 [[package]]
@@ -442,12 +444,12 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.1",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -461,21 +463,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.20.0"
+name = "hyper-tls"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
+checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 dependencies = [
- "bytes 0.5.4",
- "ct-logs",
- "futures-util",
+ "bytes",
  "hyper",
- "log",
- "rustls 0.17.0",
- "rustls-native-certs",
+ "native-tls",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -500,11 +497,11 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.4.12",
+ "bytes",
 ]
 
 [[package]]
@@ -554,12 +551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
-name = "lock_api"
-version = "0.3.4"
+name = "libz-sys"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
- "scopeguard",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -576,12 +576,6 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -627,10 +621,33 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.3",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
 ]
 
 [[package]]
@@ -643,6 +660,34 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+dependencies = [
+ "socket2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -698,35 +743,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "openssl"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "parking_lot"
-version = "0.9.0"
+name = "openssl-sys"
+version = "0.9.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
- "rustc_version",
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.6.2"
+name = "ordered-float"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+checksum = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi 0.3.8",
+ "num-traits",
 ]
 
 [[package]]
@@ -766,6 +821,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "ppv-lite86"
@@ -885,55 +946,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
- "base64 0.11.0",
- "bytes 0.5.4",
+ "base64",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.1",
+ "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.17.0",
  "serde",
- "serde_json",
  "serde_urlencoded",
  "time",
  "tokio",
- "tokio-rustls",
+ "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -941,57 +994,12 @@ name = "rr-rs"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "dotenv",
  "log",
  "pretty_env_logger",
- "serenity",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustls"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
-dependencies = [
- "base64 0.10.1",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
-dependencies = [
- "base64 0.11.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
-dependencies = [
- "openssl-probe",
- "rustls 0.17.0",
- "schannel",
- "security-framework",
+ "tokio",
+ "twilight",
 ]
 
 [[package]]
@@ -1008,22 +1016,6 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1050,27 +1042,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-mappable-seq"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45af185cf6beda66f209daec48034a256da2cc0ad518c52a79e76e52afcaefe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -1096,6 +1092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,33 +1112,6 @@ dependencies = [
  "itoa",
  "serde",
  "url",
-]
-
-[[package]]
-name = "serenity"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3dcb21751f749cd60c0779dddb08a8d339d87b79318c536eaf875b3985c22c"
-dependencies = [
- "base64 0.11.0",
- "bitflags",
- "chrono",
- "command_attr",
- "flate2",
- "log",
- "parking_lot",
- "reqwest",
- "rustls 0.16.0",
- "serde",
- "serde_json",
- "static_assertions",
- "threadpool",
- "tungstenite",
- "typemap",
- "url",
- "uwl",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1147,19 +1127,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+dependencies = [
+ "arc-swap",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
 
 [[package]]
 name = "smallvec"
@@ -1168,16 +1149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "socket2"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "syn"
@@ -1188,6 +1169,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1209,15 +1204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,28 +1219,58 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
+ "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
+ "mio-uds",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
+ "tokio-macros",
+ "winapi 0.3.8",
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.13.0"
+name = "tokio-macros"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "futures-core",
- "rustls 0.17.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
  "tokio",
- "webpki",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+dependencies = [
+ "futures",
+ "log",
+ "native-tls",
+ "pin-project",
+ "tokio",
+ "tokio-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1263,7 +1279,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -1278,12 +1294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,17 +1301,18 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tungstenite"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0c2bd5aeb7dcd2bb32e472c8872759308495e5eccc942e929a513cd8d36110"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "byteorder",
- "bytes 0.4.12",
- "http 0.1.21",
+ "bytes",
+ "http",
  "httparse",
  "input_buffer",
  "log",
+ "native-tls",
  "rand",
  "sha-1",
  "url",
@@ -1309,12 +1320,112 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+name = "twilight"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
 dependencies = [
- "unsafe-any",
+ "twilight-builders",
+ "twilight-cache",
+ "twilight-command-parser",
+ "twilight-gateway",
+ "twilight-http",
+ "twilight-model",
+]
+
+[[package]]
+name = "twilight-builders"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "twilight-model",
+]
+
+[[package]]
+name = "twilight-cache"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "twilight-cache-inmemory",
+ "twilight-cache-trait",
+]
+
+[[package]]
+name = "twilight-cache-inmemory"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "futures",
+ "log",
+ "twilight-cache-trait",
+ "twilight-gateway",
+ "twilight-model",
+]
+
+[[package]]
+name = "twilight-cache-trait"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "async-trait",
+ "twilight-model",
+]
+
+[[package]]
+name = "twilight-command-parser"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "unicase",
+]
+
+[[package]]
+name = "twilight-gateway"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "flate2",
+ "futures",
+ "log",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "twilight-http",
+ "twilight-model",
+ "url",
+]
+
+[[package]]
+name = "twilight-http"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "futures",
+ "log",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "twilight-model",
+ "url",
+]
+
+[[package]]
+name = "twilight-model"
+version = "0.1.0"
+source = "git+https://github.com/twilight-rs/twilight.git#934c6e519ecc6ed844cff1b742f4253fad10913a"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde-mappable-seq",
+ "serde-value",
+ "serde_repr",
 ]
 
 [[package]]
@@ -1347,7 +1458,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -1355,21 +1466,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -1389,10 +1485,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
-name = "uwl"
-version = "0.6.0"
+name = "vcpkg"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bf03e0ca70d626ecc4ba6b0763b934b6f2976e8c744088bb3c1d646fbb1ad0"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "version_check"
@@ -1492,25 +1588,6 @@ checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+chrono = "0.4.11"
 dotenv = "0.15"
 log = "0.4"
 pretty_env_logger = "0.4"
-serenity = "0.8.6"
+tokio = "0.2.21"
+
+[dependencies.twilight]
+git = "https://github.com/twilight-rs/twilight.git"

--- a/src/commands/avatar.rs
+++ b/src/commands/avatar.rs
@@ -1,9 +1,10 @@
-use serenity::{client::Context, model::channel::Message, Error};
+use anyhow::Result;
+use twilight::{http::Client as HttpClient, model::channel::Message};
 
-use crate::util;
+use crate::{model::Response, util};
 
-pub fn avatar(ctx: &Context, msg: &Message, search_str: &str) -> Option<Result<Message, Error>> {
-    let found_user = util::find_member(&ctx, &msg, &search_str);
+pub async fn avatar(msg: &Message, http: &HttpClient, content: &str) -> Result<Response> {
+    let found_user = util::find_member(&ctx, &msg, &content);
 
     match found_user {
         Some(user) => match user.avatar_url() {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
-// mod avatar;
+mod avatar;
 // mod owo;
 mod ping;
 
-// pub use avatar::avatar;
+pub use avatar::avatar;
 // pub use owo::owo;
 pub use ping::ping;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
-mod avatar;
-mod owo;
+// mod avatar;
+// mod owo;
 mod ping;
 
-pub use avatar::avatar;
-pub use owo::owo;
+// pub use avatar::avatar;
+// pub use owo::owo;
 pub use ping::ping;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
 mod avatar;
-// mod owo;
+mod owo;
 mod ping;
 
 pub use avatar::avatar;
-// pub use owo::owo;
+pub use owo::owo;
 pub use ping::ping;

--- a/src/commands/owo.rs
+++ b/src/commands/owo.rs
@@ -1,4 +1,10 @@
-pub fn owo(ctx: &Context, msg: &Message) -> Option<Result<Message, Error>> {
+use anyhow::Result;
+use crate::{
+    model::{MessageContext, Response},
+    util,
+};
+
+pub async fn owo(context: &MessageContext) -> Result<Response> {
     let grid = "O
 O X X O X O X O X O X X O
 X O O X X O X O X X O O X
@@ -10,5 +16,11 @@ O X X O X X X X X O X X O";
         .replace("O", "<:a:279251926409936896>")
         .replace("X", "<:a:368359173618008064>");
 
-    Some(msg.channel_id.say(&ctx, &owo))
+    let sent = context
+        .http
+        .create_message(context.message.channel_id)
+        .content(owo)
+        .await;
+
+    Ok(util::construct_response(sent))
 }

--- a/src/commands/owo.rs
+++ b/src/commands/owo.rs
@@ -1,5 +1,3 @@
-use serenity::{client::Context, model::channel::Message, Error};
-
 pub fn owo(ctx: &Context, msg: &Message) -> Option<Result<Message, Error>> {
     let grid = "O
 O X X O X O X O X O X X O

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,17 +1,24 @@
-use serenity::{client::Context, model::channel::Message, Error};
+use anyhow::Result;
+use twilight::{http::Client as HttpClient, model::channel::Message};
 
-pub fn ping(ctx: &Context, msg: &Message) -> Option<Result<Message, Error>> {
-    match msg.channel_id.say(&ctx, "pong!") {
-        Ok(mut sent) => {
-            let latency = sent.timestamp.timestamp_millis() - msg.timestamp.timestamp_millis();
+use crate::{model::Response, util};
 
-            // i can't figure out a way to care about this result
-            let _ = sent.edit(ctx, |m| {
-                m.content(format!("🏓 Message send latency: {} ms", latency))
-            });
+pub async fn ping(msg: &Message, http: &HttpClient) -> Result<Response> {
+    let sent = http.create_message(msg.channel_id).content("pong!").await;
 
-            Some(Ok(sent))
-        }
-        Err(why) => Some(Err(why)),
-    }
+    Ok(util::construct_response(sent))
+
+    // match msg.channel_id.say(&ctx, "pong!") {
+    //     Ok(mut sent) => {
+    //         let latency = sent.timestamp.timestamp_millis() - msg.timestamp.timestamp_millis();
+
+    //         // i can't figure out a way to care about this result
+    //         let _ = sent.edit(ctx, |m| {
+    //             m.content(format!("🏓 Message send latency: {} ms", latency))
+    //         });
+
+    //         Some(Ok(sent))
+    //     }
+    //     Err(why) => Some(Err(why)),
+    // }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -26,7 +26,7 @@ pub async fn handle_event(event_context: EventContext) -> anyhow::Result<()> {
 
                 // execute the command
                 let result = match command {
-                    // "avatar" => commands::avatar(&msg, &http, &content).await,
+                    "avatar" => commands::avatar(&message_context).await,
                     "ping" => commands::ping(&message_context).await,
                     // "owo" => commands::owo(&ctx, &msg),
                     _ => Ok(Response::None),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -28,7 +28,7 @@ pub async fn handle_event(event_context: EventContext) -> anyhow::Result<()> {
                 let result = match command {
                     "avatar" => commands::avatar(&message_context).await,
                     "ping" => commands::ping(&message_context).await,
-                    // "owo" => commands::owo(&ctx, &msg),
+                    "owo" => commands::owo(&message_context).await,
                     _ => Ok(Response::None),
                 };
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,27 +1,33 @@
 use log::{error, info};
-use twilight::{gateway::shard::Event, http::Client as HttpClient};
+use twilight::gateway::shard::Event;
 
 use crate::{
     commands,
-    model::{Context, Response},
+    model::{EventContext, MessageContext, Response},
 };
 
-pub async fn handle_event(event: (u64, Event), http: HttpClient) -> anyhow::Result<()> {
-    match event {
-        (_, Event::MessageCreate(msg)) if msg.content.starts_with("katze") => {
+pub async fn handle_event(event_context: EventContext) -> anyhow::Result<()> {
+    match event_context.event {
+        Event::MessageCreate(msg) if msg.content.starts_with("katze") => {
             let content = msg.content.to_owned();
             let mut content = content.split(' ');
             let _ = content.next();
 
             // read the next word from the message as the command name
             if let Some(command) = content.next() {
-                // join the rest of the content into a string for the commands to use
-                let content = content.collect::<Vec<_>>().join(&" ");
+                // create a message context for convenience
+                let message_context = MessageContext {
+                    cache: event_context.cache,
+                    http: event_context.http,
+                    // deref the Box, and then take ownership of the Message
+                    message: (*msg).0,
+                    content: content.collect::<Vec<_>>().join(&" "),
+                };
 
                 // execute the command
                 let result = match command {
                     // "avatar" => commands::avatar(&msg, &http, &content).await,
-                    "ping" => commands::ping(&msg, &http).await,
+                    "ping" => commands::ping(&message_context).await,
                     // "owo" => commands::owo(&ctx, &msg),
                     _ => Ok(Response::None),
                 };
@@ -29,6 +35,7 @@ pub async fn handle_event(event: (u64, Event), http: HttpClient) -> anyhow::Resu
                 match result {
                     Ok(response) => match response {
                         Response::Some(reply) => {
+                            // this is a reply success
                             info!(
                                 "channel:{} timestamp:{} command:{}",
                                 reply.channel_id.to_string(),
@@ -36,13 +43,27 @@ pub async fn handle_event(event: (u64, Event), http: HttpClient) -> anyhow::Resu
                                 command
                             );
                         }
-                        // TODO: handle errors better
-                        // this is a message send error
-                        Response::Err(why) => error!("{:?}", why),
+                        Response::Err(why) => {
+                            // this is a message send error
+                            error!(
+                                "channel:{} timestamp:{} command:{}\nerror sending message\n{:?}",
+                                message_context.message.channel_id,
+                                message_context.message.timestamp,
+                                command,
+                                why
+                            );
+                        }
                         Response::None => {}
-                    }
+                    },
                     Err(why) => {
                         // this is a command execution error
+                        error!(
+                            "channel:{} timestamp:{}\nerror processing command:{}\n{:?}",
+                            message_context.message.channel_id,
+                            message_context.message.timestamp,
+                            command,
+                            why
+                        );
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,41 @@
-use anyhow::{Context, Error};
 use dotenv;
 use pretty_env_logger;
-use serenity::Client;
+use tokio::stream::StreamExt;
+use twilight::{
+    cache::InMemoryCache,
+    gateway::{Cluster, ClusterConfig},
+    http::Client as HttpClient,
+    model::gateway::GatewayIntents,
+};
 
 mod commands;
 mod handler;
+mod model;
 mod util;
-use crate::handler::Handler;
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     // load dotenv and logger
     dotenv::dotenv().ok();
     pretty_env_logger::init();
 
     // create and start bot
-    let mut client = Client::new(dotenv::var("TOKEN").unwrap().as_str(), Handler)?;
-    client
-        .start_autosharded()
-        .context("Failed to start client")?;
+    let token = dotenv::var("TOKEN")?;
+    let token = token.as_str();
+    let http = HttpClient::new(token);
+    let cache = InMemoryCache::new();
+
+    let cluster_config = ClusterConfig::builder(token)
+        .intents(Some(GatewayIntents::GUILD_MESSAGES))
+        .build();
+    let cluster = Cluster::new(cluster_config);
+    cluster.up().await?;
+
+    let mut events = cluster.events().await;
+    while let Some(event) = events.next().await {
+        cache.update(&event.1).await?;
+        tokio::spawn(handler::handle_event(event, http.clone()));
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,15 @@ async fn main() -> anyhow::Result<()> {
     let mut events = cluster.events().await;
     while let Some(event) = events.next().await {
         cache.update(&event.1).await?;
-        tokio::spawn(handler::handle_event(event, http.clone()));
+
+        let context = model::EventContext {
+            cache: cache.clone(),
+            http: http.clone(),
+            event: event.1,
+            id: event.0,
+        };
+
+        tokio::spawn(handler::handle_event(context));
     }
 
     Ok(())

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,18 @@
+use twilight::{
+    http::{error::Error, Client as HttpClient},
+    model::channel::Message,
+};
+
+#[derive(Debug)]
+pub enum Response {
+    Some(Message),
+    Err(Error),
+    None,
+}
+
+#[derive(Debug)]
+pub struct Context {
+    message: Message,
+    http: HttpClient,
+    content: String,
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,6 @@
 use twilight::{
+    cache::InMemoryCache,
+    gateway::shard::Event,
     http::{error::Error, Client as HttpClient},
     model::channel::Message,
 };
@@ -11,8 +13,17 @@ pub enum Response {
 }
 
 #[derive(Debug)]
-pub struct Context {
-    message: Message,
-    http: HttpClient,
-    content: String,
+pub struct EventContext {
+    pub cache: InMemoryCache,
+    pub http: HttpClient,
+    pub event: Event,
+    pub id: u64,
+}
+
+#[derive(Debug)]
+pub struct MessageContext {
+    pub cache: InMemoryCache,
+    pub http: HttpClient,
+    pub content: String,
+    pub message: Message,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,56 +1,31 @@
-use log::{error, info};
-use serenity::{
-    client::Context,
-    model::{channel::Message, user::User},
-    Error,
-};
+use twilight::{http::error::Result as HttpResult, model::channel::Message};
 
-fn handle_http_error(msg: &Message, command: &str, why: serenity::Error) {
-    if let serenity::Error::Http(response) = why {
-        if let serenity::http::HttpError::UnsuccessfulRequest(response) = *response {
-            error!(
-                "channel:{} timestamp:{} command:{} error:{} {}",
-                msg.channel_id,
-                msg.timestamp.to_rfc3339(),
-                command,
-                response.status_code,
-                response.error.message,
-            );
-        }
-    }
-}
+use crate::model::Response;
 
-pub fn find_member(ctx: &Context, msg: &Message, search_str: &str) -> Option<User> {
-    if msg.mentions.first().is_some() {
-        return msg.mentions.first().cloned();
-    }
+// pub fn find_member(ctx: &Context, msg: &Message, search_str: &str) -> Option<User> {
+//     if msg.mentions.first().is_some() {
+//         return msg.mentions.first().cloned();
+//     }
+//
+//     let guild_lock = msg.channel(&ctx.cache)?.guild()?;
+//     let guild = guild_lock.read();
+//     let members = guild.members(&ctx.cache).ok()?;
+//
+//     let found = members
+//         .iter()
+//         .find(|&member| member.display_name().into_owned() == search_str.to_string());
+//
+//     if found.is_some() {
+//         let user = found.unwrap().user.read();
+//         return Some(user.clone());
+//     } else {
+//         return Some(msg.author.clone());
+//     }
+// }
 
-    let guild_lock = msg.channel(&ctx.cache)?.guild()?;
-    let guild = guild_lock.read();
-    let members = guild.members(&ctx.cache).ok()?;
-
-    let found = members
-        .iter()
-        .find(|&member| member.display_name().into_owned() == search_str.to_string());
-
-    if found.is_some() {
-        let user = found.unwrap().user.read();
-        return Some(user.clone());
-    } else {
-        return Some(msg.author.clone());
-    }
-}
-
-pub fn handle_sent_message(msg: &Message, result: Result<Message, Error>, command: &str) {
-    match result {
-        Ok(sent) => {
-            info!(
-                "channel:{} timestamp:{} command:{}",
-                sent.channel_id,
-                sent.timestamp.to_rfc3339(),
-                command,
-            );
-        }
-        Err(why) => handle_http_error(&msg, &command, why),
+pub fn construct_response(sent: HttpResult<Message>) -> Response {
+    match sent {
+        Ok(msg) => Response::Some(msg),
+        Err(why) => Response::Err(why),
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,27 +1,52 @@
-use twilight::{http::error::Result as HttpResult, model::channel::Message};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use crate::model::Response;
+use anyhow::Result;
+use twilight::{
+    http::error::Result as HttpResult,
+    model::{channel::Message, user::User},
+};
 
-// pub fn find_member(ctx: &Context, msg: &Message, search_str: &str) -> Option<User> {
-//     if msg.mentions.first().is_some() {
-//         return msg.mentions.first().cloned();
-//     }
-//
-//     let guild_lock = msg.channel(&ctx.cache)?.guild()?;
-//     let guild = guild_lock.read();
-//     let members = guild.members(&ctx.cache).ok()?;
-//
-//     let found = members
-//         .iter()
-//         .find(|&member| member.display_name().into_owned() == search_str.to_string());
-//
-//     if found.is_some() {
-//         let user = found.unwrap().user.read();
-//         return Some(user.clone());
-//     } else {
-//         return Some(msg.author.clone());
-//     }
-// }
+use crate::model::{MessageContext, Response};
+
+#[derive(Debug)]
+enum FindMemberError {
+    NoGuild,
+}
+
+impl Display for FindMemberError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoGuild => f.write_str("no guild found"),
+        }
+    }
+}
+
+impl std::error::Error for FindMemberError {}
+
+pub async fn find_member(context: &MessageContext, search_str: &str) -> Result<Option<User>> {
+    if !context.message.mentions.is_empty() {
+        let user = context.message.mentions.values().next().unwrap();
+        return Ok(Some(user.to_owned()));
+    }
+
+    // TODO: wait for CachedGuild.members
+    //
+    // let guild_id = context.message.guild_id.ok_or(FindMemberError::NoGuild)?;
+    // let guild = context.cache.guild(guild_id).await?;
+
+    // let found = members
+    //     .iter()
+    //     .find(|&member| member.display_name().into_owned() == search_str.to_string());
+
+    // if found.is_some() {
+    //     let user = found.unwrap().user.read();
+    //     return Some(user.clone());
+    // } else {
+    //     return Some(msg.author.clone());
+    // }
+
+    Ok(None)
+}
 
 pub fn construct_response(sent: HttpResult<Message>) -> Response {
     match sent {


### PR DESCRIPTION
This pull request migrates the codebase from `serenity-rs` to `twilight-rs`. `serenity-rs`' async implementation is not ready, and I need to use `sqlx` in the future, which is only async. Also, `twilight-rs` allows for modular implementation of crates, which will allow for further optimization down the line. 